### PR TITLE
feat(CI): provide built binaries at GitHub release page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - master
 
-permissions:
-  contents: read
-  id-token: write
-  packages: write
-  security-events: write
-
 jobs:
   release-please:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -34,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
       issues: write
       pull-requests: write
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: ci
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: read
@@ -16,7 +13,7 @@ permissions:
 
 jobs:
   release-please:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+  security-events: write
+
+jobs:
+  release-please:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - id: release-please
+        name: Release please
+        uses: googleapis/release-please-action@v4
+        with:
+          release-type: go
+
+  goreleaser:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0
+      - name: Setup Cosign CLI
+        uses: sigstore/cosign-installer@v3
+      - name: Install goreleaser
+        run: |
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install -y goreleaser
+          goreleaser --version
+      - id: semantic-release
+        name: Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: goreleaser release --release-notes CHANGELOG.md --clean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
     permissions:
+      issues: write
       contents: write
       pull-requests: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin
 cmd/nerdlog-tui/nerdlog-tui
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj paste number backup
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - freebsd
+      - linux
+      - windows
+      - darwin
+    main: ./cmd/nerdlog-tui
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- tolower .Os }}_
+      {{- if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+binary_signs:
+  - cmd: cosign
+    args:
+      - sign-blob
+      - --output-signature=${signature}
+      - --output-certificate=${certificate}
+      - ${artifact}
+      - --yes
+    certificate: '${artifact}_{{- tolower .Os }}_{{- if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}.pem'
+    signature: '${artifact}_{{- tolower .Os }}_{{- if eq .Arch "386" }}i386{{- else }}{{ .Arch }}{{ end }}{{- if .Arm }}v{{ .Arm }}{{ end }}.sig'
+    output: true
+
+checksum:
+  name_template: checksums.txt
+
+sboms:
+  - id: archive
+    artifacts: archive
+  - id: source
+    artifacts: source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 1.0.0 (2025-04-26)
+
+
+### Features
+
+* **CI:** add goreleaser with release-please action ([1d8bb58](https://github.com/meysam81/nerdlog/commit/1d8bb5890a6bd16431b2cf59ce9118f01f3f1d0f))
+
+
+### Bug Fixes
+
+* **CI:** allow creating labels to release please action ([4918c20](https://github.com/meysam81/nerdlog/commit/4918c2061286982ecac0c3cf6d1857123c60748f))
+* use master as the default branch ([e05406d](https://github.com/meysam81/nerdlog/commit/e05406d5217e52d1539f6b7d53b8cc2b2039599c))


### PR DESCRIPTION
hey @dimonomid 

Great project

I didn't find any pre-compiled binaries so I took a brief time to provide the CI workflow to provide those in your GitHub release page.

You can see a successful run here:

<details>
<summary>
Screenshot for when log retention expires
</summary>

![ci-run](https://github.com/user-attachments/assets/24c85fef-edbe-4bf5-b457-d1a16da30a51)

</details>



<https://github.com/meysam81/nerdlog/actions/runs/14677548574/job/41196021607#step:6:1109>

And here's how you'd merge your release PR to get a new tag as well as a new GitHub release (accompanied by that build jub above):

https://github.com/meysam81/nerdlog/pull/1

In the end, you'll get a whole bunch of compiled `nerdlog` binaries in your GitHub release page just like this one (with cosign keyless signature, sbom generation as well as checksum):

<https://github.com/meysam81/nerdlog/releases/tag/v1.0.0>

Although [semantic-release](https://semantic-release.gitbook.io/semantic-release) would also be a good option and I have done both in the past, the [release-please-action](https://github.com/googleapis/release-please-action) puts you more in the driving seat.

Cheers :clinking_glasses: 
